### PR TITLE
HY - create database table for Instructor

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Instructor.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Instructor.java
@@ -1,0 +1,17 @@
+package edu.ucsb.cs156.frontiers.entities;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * This is a JPA entity that represents an Instructor.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "instructors")
+public class Instructor {
+    @Id
+    private String email;
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/InstructorRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/InstructorRepository.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.frontiers.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.frontiers.entities.Instructor;
+import java.util.Optional;
+
+/**
+ * The InstructorRepository is a repository for Instructor entities.
+ */
+
+@Repository
+public interface InstructorRepository extends CrudRepository<Instructor, String> {
+  /**
+   * This method returns an Instructor entity with a given email.
+   * @param email email address of the instructor
+   * @return Optional of Instructor (empty if not found)
+   */
+  Optional<Instructor> findByEmail(String email);
+}

--- a/src/main/resources/db/migration/changes/007-create-Instructors.json
+++ b/src/main/resources/db/migration/changes/007-create-Instructors.json
@@ -1,7 +1,7 @@
 { "databaseChangeLog": [
     {
       "changeSet": {
-        "id": "007-create-Instructors.json",
+        "id": "007-create-Instructors",
         "author": "Hannya",
         "preConditions": [
           {

--- a/src/main/resources/db/migration/changes/007-create-Instructors.json
+++ b/src/main/resources/db/migration/changes/007-create-Instructors.json
@@ -1,7 +1,7 @@
 { "databaseChangeLog": [
     {
       "changeSet": {
-        "id": "Instructor-1",
+        "id": "007-create-Instructors.json",
         "author": "Hannya",
         "preConditions": [
           {

--- a/src/main/resources/db/migration/changes/007-create-Instructors.json
+++ b/src/main/resources/db/migration/changes/007-create-Instructors.json
@@ -1,0 +1,43 @@
+{ "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "Instructor-1",
+        "author": "Hannya",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "INSTRUCTORS"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "INSTRUCTORS_PK"
+                    },
+                    "name": "EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ]
+              ,
+              "tableName": "INSTRUCTORS"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #2 

In this PR, I add a database table for Instructor with one and only one field: 
```
private String email
```

Dokku deployment: https://frontiers-dev-hannya.dokku-07.cs.ucsb.edu
You can test this by running on dokku and connecting to the postgres databse, type:
```
dokku postgres:connect frontiers-dev-hannya-db
```
![image](https://github.com/user-attachments/assets/20847d94-36ca-4e96-9bfc-86d9faed5f4c)
