### PR TITLE
HY - Instructor DELETE operation implementation

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/InstructorsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/InstructorsController.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.frontiers.entities.Instructor;
@@ -9,6 +8,7 @@ import edu.ucsb.cs156.frontiers.repositories.InstructorRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,7 +37,7 @@ public class InstructorsController extends ApiController {
     ObjectMapper mapper;
 
     /**
-     * Create a new Instructor.
+     * Create a new Instructor, available only to Admins.
      * 
      * @param email the email of the instructor
      * @return the created Instructor
@@ -55,7 +55,7 @@ public class InstructorsController extends ApiController {
     }
 
     /**
-     * This method returns a list of all instructors, available only to Admins.
+     * Get a list of all instructors, available only to Admins.
      * 
      * @return a list of all instructors
      */
@@ -65,5 +65,24 @@ public class InstructorsController extends ApiController {
     public Iterable<Instructor> allInstructors() {
         Iterable<Instructor> instructors = instructorRepository.findAll();
         return instructors;
+    }
+
+    /**
+     * Delete an instructor by email, available only to Admins.
+     */
+    @Operation(summary = "Delete an Instructor by email")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteInstructor(
+            @RequestParam String email) {
+        Instructor instructor = instructorRepository.findById(email).orElse(null);
+
+        if (instructor == null) {
+            return ResponseEntity.status(404)
+                    .body(String.format("Instructor with email %s not found.", email));
+        }
+
+        instructorRepository.delete(instructor);
+        return ResponseEntity.status(200).body(String.format("Instructor with email %s deleted.", email));
     }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/InstructorsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/InstructorsControllerTests.java
@@ -1,13 +1,21 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
-import edu.ucsb.cs156.frontiers.repositories.UserRepository;
-import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
-import edu.ucsb.cs156.frontiers.ControllerTestCase;
-import edu.ucsb.cs156.frontiers.entities.Instructor;
-import edu.ucsb.cs156.frontiers.repositories.InstructorRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -15,16 +23,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.Instructor;
+import edu.ucsb.cs156.frontiers.repositories.InstructorRepository;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
 
 @WebMvcTest(controllers = InstructorsController.class)
 @Import(TestConfig.class)

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/InstructorsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/InstructorsControllerTests.java
@@ -19,7 +19,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -30,80 +29,121 @@ import static org.mockito.Mockito.when;
 @Import(TestConfig.class)
 public class InstructorsControllerTests extends ControllerTestCase {
 
-    @MockBean
-    InstructorRepository instructorRepository;
-    @MockBean
-    UserRepository userRepository;
+        @MockBean
+        InstructorRepository instructorRepository;
+        @MockBean
+        UserRepository userRepository;
 
-    // Tests for the POST endpoint
-    @Test
-    public void logged_out_users_cannot_post() throws Exception {
-        mockMvc.perform(post("/api/admin/instructors/post"))
-                .andExpect(status().is(403)); // logged out users cannot post
-    }
+        // Tests for the POST endpoint
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/admin/instructors/post"))
+                                .andExpect(status().is(403)); // logged out users cannot post
+        }
 
-    @WithMockUser(roles = { "USER" })
-    @Test
-    public void logged_in_users_cannot_post() throws Exception {
-        mockMvc.perform(post("/api/admin/instructors/post"))
-                .andExpect(status().is(403)); // logged in users cannot post
-    }
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/admin/instructors/post"))
+                                .andExpect(status().is(403)); // logged in users cannot post
+        }
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void logged_in_admins_can_post() throws Exception {
-        // arrage
-        Instructor instructor = Instructor.builder()
-                .email("ins@ucsb.edu")
-                .build();
-        when(instructorRepository.findAll()).thenReturn(new ArrayList<>(Arrays.asList(instructor)));
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admins_can_post() throws Exception {
+                // arrage
+                Instructor instructor = Instructor.builder()
+                                .email("ins@ucsb.edu")
+                                .build();
+                when(instructorRepository.findAll()).thenReturn(new ArrayList<>(Arrays.asList(instructor)));
 
-        // act
-        MvcResult response = mockMvc.perform(post("/api/admin/instructors/post?email=ins@ucsb.edu").with(csrf()))
-                .andExpect(status().isOk())
-                .andReturn();
+                // act
+                MvcResult response = mockMvc
+                                .perform(post("/api/admin/instructors/post?email=ins@ucsb.edu").with(csrf()))
+                                .andExpect(status().isOk())
+                                .andReturn();
 
-        // assert
-        verify(instructorRepository, times(1)).save(eq(instructor));
-        String expectedJson = mapper.writeValueAsString(instructor);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-    }
+                // assert
+                verify(instructorRepository, times(1)).save(eq(instructor));
+                String expectedJson = mapper.writeValueAsString(instructor);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 
-    // Tests for the GET endpoint
-    @Test
-    public void logged_out_users_cannot_get() throws Exception {
-        mockMvc.perform(get("/api/admin/instructors/get"))
-                .andExpect(status().is(403)); // logged out users cannot get
-    }
+        // Tests for the GET endpoint
+        @Test
+        public void logged_out_users_cannot_get() throws Exception {
+                mockMvc.perform(get("/api/admin/instructors/get"))
+                                .andExpect(status().is(403)); // logged out users cannot get
+        }
 
-    @WithMockUser(roles = { "USER" })
-    @Test
-    public void logged_in_users_cannot_get() throws Exception {
-        mockMvc.perform(get("/api/admin/instructors/get"))
-                .andExpect(status().is(403)); // logged in users cannot get
-    }
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_cannot_get() throws Exception {
+                mockMvc.perform(get("/api/admin/instructors/get"))
+                                .andExpect(status().is(403)); // logged in users cannot get
+        }
 
-    @WithMockUser(roles = { "ADMIN" })
-    @Test
-    public void logged_in_admins_can_get() throws Exception {
-        // arrage
-        Instructor instructor = Instructor.builder()
-                .email("ins@ucsb.edu")
-                .build();
-        ArrayList<Instructor> expectedInstructors = new ArrayList<>();
-        expectedInstructors.addAll(Arrays.asList(instructor));
-        when(instructorRepository.findAll()).thenReturn(new ArrayList<>(Arrays.asList(instructor)));
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admins_can_get() throws Exception {
+                // arrage
+                Instructor instructor = Instructor.builder()
+                                .email("ins@ucsb.edu")
+                                .build();
+                ArrayList<Instructor> expectedInstructors = new ArrayList<>();
+                expectedInstructors.addAll(Arrays.asList(instructor));
+                when(instructorRepository.findAll()).thenReturn(new ArrayList<>(Arrays.asList(instructor)));
 
-        // act
-        MvcResult response = mockMvc.perform(get("/api/admin/instructors/get"))
-                .andExpect(status().isOk())
-                .andReturn();
+                // act
+                MvcResult response = mockMvc.perform(get("/api/admin/instructors/get"))
+                                .andExpect(status().isOk())
+                                .andReturn();
 
-        // assert
-        verify(instructorRepository, times(1)).findAll();
-        String expectedJson = mapper.writeValueAsString(expectedInstructors);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-    }
+                // assert
+                verify(instructorRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedInstructors);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for the DELETE endpoint
+        @Test
+        public void logged_out_users_cannot_delete() throws Exception {
+                mockMvc.perform(delete("/api/admin/instructors/delete"))
+                                .andExpect(status().is(403)); // logged out users cannot delete
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_cannot_delete() throws Exception {
+                mockMvc.perform(delete("/api/admin/instructors/delete"))
+                                .andExpect(status().is(403)); // logged in users cannot delete
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admins_can_delete() throws Exception {
+                // Arrange
+                Instructor instructor = Instructor.builder()
+                                .email("ins@ucsb.edu")
+                                .build();
+                when(instructorRepository.findById(eq("ins@ucsb.edu"))).thenReturn(Optional.of(instructor));
+
+                // Act
+                MvcResult response = mockMvc.perform(delete("/api/admin/instructors/delete") // Correct the URL
+                                .param("email", "ins@ucsb.edu") // Add the correct parameter
+                                .with(csrf())) // CSRF protection
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                // Assert
+                verify(instructorRepository, times(1)).findById("ins@ucsb.edu");
+                verify(instructorRepository, times(1)).delete(instructor); // Ensure that the correct instructor is deleted
+
+                // Assert that the response message matches the expected format
+                String expectedMessage = String.format("Instructor with email %s deleted.", instructor.getEmail());
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedMessage, responseString);
+        }
 }


### PR DESCRIPTION
Closes #32 
Merge this after #33 

In this PR, DELETE operation and its unit tests are implemented for Instructor table.

You can test this on this dokku and check the Swagger: https://frontiers-dev-hannya.dokku-07.cs.ucsb.edu/
![image](https://github.com/user-attachments/assets/a3cc6e6e-90ec-4928-aac0-3c1f53663f73)
