### PR TITLE
yl - add backend list endpoint for CoursesController and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -4,12 +4,22 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,10 +31,17 @@ import org.springframework.web.bind.annotation.RestController;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.errors.InvalidInstallationTypeException;
 import edu.ucsb.cs156.frontiers.models.CurrentUser;
+import edu.ucsb.cs156.frontiers.models.RosterStudentDTO;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import edu.ucsb.cs156.frontiers.services.OrganizationLinkerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -36,20 +53,27 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @Slf4j
 public class CoursesController extends ApiController {
-    
+
     @Autowired
     private CourseRepository courseRepository;
 
-    @Autowired private OrganizationLinkerService linkerService;
+    @Autowired
+    private UserRepository userRepository;
 
-     /**
+    @Autowired
+    private RosterStudentRepository rosterStudentRepository;
+
+    @Autowired
+    private OrganizationLinkerService linkerService;
+
+    /**
      * This method creates a new Course.
      * 
-    * @param orgName the name of the organization
-    * @param courseName the name of the course
-    * @param term the term of the course
-    * @param school the school of the course
-    * @return the created course
+     * @param orgName    the name of the organization
+     * @param courseName the name of the course
+     * @param term       the term of the course
+     * @param school     the school of the course
+     * @return the created course
      */
 
     @Operation(summary = "Create a new course")
@@ -59,10 +83,8 @@ public class CoursesController extends ApiController {
             @Parameter(name = "orgName") @RequestParam String orgName,
             @Parameter(name = "courseName") @RequestParam String courseName,
             @Parameter(name = "term") @RequestParam String term,
-            @Parameter(name = "school") @RequestParam String school
-           )
-            {
-        //get current date right now and set status to pending
+            @Parameter(name = "school") @RequestParam String school) {
+        // get current date right now and set status to pending
         CurrentUser currentUser = getCurrentUser();
         Course course = Course.builder()
                 .orgName(orgName)
@@ -76,72 +98,91 @@ public class CoursesController extends ApiController {
         return savedCourse;
     }
 
-      /**
+    /**
      * This method returns a list of courses.
+     * 
      * @return a list of all courses.
      */
     @Operation(summary = "List all courses")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/all")
-    public Iterable<Course> allCourses(
-    ) {
+    public Iterable<Course> allCourses() {
         Iterable<Course> courses = courseRepository.findAll();
         return courses;
     }
 
-
     /**
-     * <p>This is the outgoing method, redirecting from Frontiers to GitHub to allow a Course to be linked to a GitHub Organization.
-     * It redirects from Frontiers to the GitHub app installation process, and will return with the {@link #addInstallation(Optional, String, String, Long) addInstallation()} endpoint
+     * <p>
+     * This is the outgoing method, redirecting from Frontiers to GitHub to allow a
+     * Course to be linked to a GitHub Organization.
+     * It redirects from Frontiers to the GitHub app installation process, and will
+     * return with the {@link #addInstallation(Optional, String, String, Long)
+     * addInstallation()} endpoint
      * </p>
+     * 
      * @param courseId id of the course to be linked to
-     * @return dynamically loaded url to install Frontiers to a Github Organization, with the courseId marked as the state parameter, which GitHub will return.
+     * @return dynamically loaded url to install Frontiers to a Github Organization,
+     *         with the courseId marked as the state parameter, which GitHub will
+     *         return.
      *
      */
     @Operation(summary = "Authorize Frontiers to a Github Course")
     @PreAuthorize("hasRole('ROLE_PROFESSOR')")
     @GetMapping("/redirect")
-    public ResponseEntity<Void> linkCourse(@Parameter Long courseId) throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
+    public ResponseEntity<Void> linkCourse(@Parameter Long courseId)
+            throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException {
         String newUrl = linkerService.getRedirectUrl();
-        newUrl += "/installations/new?state="+courseId;
-        //found this convenient solution here: https://stackoverflow.com/questions/29085295/spring-mvc-restcontroller-and-redirect
+        newUrl += "/installations/new?state=" + courseId;
+        // found this convenient solution here:
+        // https://stackoverflow.com/questions/29085295/spring-mvc-restcontroller-and-redirect
         return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(HttpHeaders.LOCATION, newUrl).build();
     }
-
 
     /**
      *
      * @param installation_id id of the incoming GitHub Organization installation
-     * @param setup_action whether the permissions are installed or updated. Required RequestParam but not used by the method.
-     * @param code token to be exchanged with GitHub to ensure the request is legitimate and not spoofed.
-     * @param state id of the Course to be linked with the GitHub installation.
-     * @return ResponseEntity, returning /success if the course was successfully linked or /noperms if the user does not have the permission to install the application on GitHub. Alternately returns 403 Forbidden if the user is not the creator.
+     * @param setup_action    whether the permissions are installed or updated.
+     *                        Required RequestParam but not used by the method.
+     * @param code            token to be exchanged with GitHub to ensure the
+     *                        request is legitimate and not spoofed.
+     * @param state           id of the Course to be linked with the GitHub
+     *                        installation.
+     * @return ResponseEntity, returning /success if the course was successfully
+     *         linked or /noperms if the user does not have the permission to
+     *         install the application on GitHub. Alternately returns 403 Forbidden
+     *         if the user is not the creator.
      */
     @Operation(summary = "Link a Course to a Github Course")
     @PreAuthorize("hasRole('ROLE_PROFESSOR')")
     @GetMapping("link")
-    public ResponseEntity<Void> addInstallation(@Parameter(name = "installationId") @RequestParam Optional<String> installation_id,
-                                                @Parameter(name = "setupAction") @RequestParam String setup_action,
-                                                @Parameter(name = "code") @RequestParam String code,
-                                                @Parameter(name = "state") @RequestParam Long state) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
-        if(installation_id.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(HttpHeaders.LOCATION, "/courses/nopermissions").build();
-        }else {
-            Course course = courseRepository.findById(state).orElseThrow(() -> new EntityNotFoundException(Course.class, state));
-            if(!(course.getCreator().getId() ==getCurrentUser().getUser().getId())) {
+    public ResponseEntity<Void> addInstallation(
+            @Parameter(name = "installationId") @RequestParam Optional<String> installation_id,
+            @Parameter(name = "setupAction") @RequestParam String setup_action,
+            @Parameter(name = "code") @RequestParam String code,
+            @Parameter(name = "state") @RequestParam Long state)
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        if (installation_id.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                    .header(HttpHeaders.LOCATION, "/courses/nopermissions").build();
+        } else {
+            Course course = courseRepository.findById(state)
+                    .orElseThrow(() -> new EntityNotFoundException(Course.class, state));
+            if (!(course.getCreator().getId() == getCurrentUser().getUser().getId())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-            }else{
+            } else {
                 String orgName = linkerService.getOrgName(installation_id.get());
                 course.setInstallationId(installation_id.get());
                 course.setOrgName(orgName);
                 courseRepository.save(course);
-                return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(HttpHeaders.LOCATION, "/admin/courses?success=True&course=" + state).build();
+                return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                        .header(HttpHeaders.LOCATION, "/admin/courses?success=True&course=" + state).build();
             }
         }
     }
 
     /**
      * This method handles the InvalidInstallationTypeException.
+     * 
      * @param e the exception
      * @return a map with the type and message of the exception
      */
@@ -150,9 +191,39 @@ public class CoursesController extends ApiController {
     public Object handleInvalidInstallationType(Throwable e) {
         return Map.of(
                 "type", e.getClass().getSimpleName(),
-                "message", e.getMessage()
-        );
+                "message", e.getMessage());
     }
 
+    /**
+     * This method returns a list of courses that the current user is enrolled.
+     * 
+     * @return a list of courses in the DTO form along with the student status in the organization.
+     */
+    @Operation(summary = "List all courses for the current student, including their org status")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/list")
+    public List<Map<String, Object>> listCoursesForCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        OAuth2User user = (OAuth2User) authentication.getPrincipal();
+        String email = user.getAttribute("email");
+        Iterable<RosterStudent> rosterStudentsIterable = rosterStudentRepository.findAllByEmail(email);
+        List<RosterStudent> rosterStudents = new ArrayList<>();
+        rosterStudentsIterable.forEach(rosterStudents::add);
+        return rosterStudents.stream()
+                .map(rs -> {
+                    Course course = rs.getCourse();
+                    RosterStudentDTO rsDto = RosterStudentDTO.from(rs);
+                    Map<String, Object> response = new LinkedHashMap<>();
+                    response.put("id", course.getId());
+                    response.put("installationId", course.getInstallationId());
+                    response.put("orgName", course.getOrgName());
+                    response.put("courseName", course.getCourseName());
+                    response.put("term", course.getTerm());
+                    response.put("school", course.getSchool());
+                    response.put("studentStatus", rsDto.getOrgStatus());
+                    return response;
+                })
+                .collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -163,7 +163,7 @@ public class RosterStudentsController extends ApiController {
     public InsertStatus upsertStudent(RosterStudent student, Course course) {
         Optional<RosterStudent> existingStudent = rosterStudentRepository.findByCourseIdAndStudentId(course.getId(),
                 student.getStudentId());
-        String convertedEmail = student.getEmail().replace("@umail.ucsb.edu","@ucsb.edu");
+        String convertedEmail = student.getEmail().replace("@umail.ucsb.edu", "@ucsb.edu");
         if (existingStudent.isPresent()) {
             RosterStudent existingStudentObj = existingStudent.get();
             existingStudentObj.setRosterStatus(RosterStatus.ROSTER);
@@ -188,11 +188,14 @@ public class RosterStudentsController extends ApiController {
 
     @PreAuthorize("hasRole('ROLE_PROFESSOR')")
     @PostMapping("/updateCourseMembership")
-    public Job updateCourseMembership(@Parameter(name = "courseId", description = "Course ID") @RequestParam Long courseId) throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
-        Course course = courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
-        if(course.getInstallationId() == null || course.getOrgName() == null){
+    public Job updateCourseMembership(
+            @Parameter(name = "courseId", description = "Course ID") @RequestParam Long courseId)
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JsonProcessingException {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+        if (course.getInstallationId() == null || course.getOrgName() == null) {
             throw new NoLinkedOrganizationException(course.getCourseName());
-        }else{
+        } else {
             UpdateOrgMembershipJob job = UpdateOrgMembershipJob.builder()
                     .rosterStudentRepository(rosterStudentRepository)
                     .organizationMemberService(organizationMemberService)
@@ -202,11 +205,12 @@ public class RosterStudentsController extends ApiController {
             return jobService.runAsJob(job);
         }
     }
-    
+
     @Operation(summary = "Link a Roster Student to a Github Account")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PutMapping("/linkGitHub")
-    public ResponseEntity<String> linkGitHub(@Parameter(name = "rosterStudentId", description = "Roster Student to be linked to") @RequestParam Long rosterStudentId){
+    public ResponseEntity<String> linkGitHub(
+            @Parameter(name = "rosterStudentId", description = "Roster Student to be linked to") @RequestParam Long rosterStudentId) {
         User currentUser = currentUserService.getUser();
         RosterStudent rosterStudent = rosterStudentRepository.findById(rosterStudentId)
                 .orElseThrow(() -> new EntityNotFoundException(RosterStudent.class, rosterStudentId));
@@ -215,7 +219,7 @@ public class RosterStudentsController extends ApiController {
             throw new AccessDeniedException("User not authorized to link this roster student");
         }
 
-        if (rosterStudent.getGithubId() != 0 && rosterStudent.getGithubLogin() != null ) {
+        if (rosterStudent.getGithubId() != 0 && rosterStudent.getGithubLogin() != null) {
             return ResponseEntity.badRequest().body("This roster student is already linked to a GitHub account");
         }
 
@@ -228,7 +232,7 @@ public class RosterStudentsController extends ApiController {
     @Operation(summary = "Get Associated Roster Students with a User")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/associatedRosterStudents")
-    public Iterable<RosterStudent> getAssociatedRosterStudents(){
+    public Iterable<RosterStudent> getAssociatedRosterStudents() {
         User currentUser = currentUserService.getUser();
         Iterable<RosterStudent> rosterStudents = rosterStudentRepository.findAllByUser((currentUser));
         return rosterStudents;

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -13,23 +13,37 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.List;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.core.Authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 import edu.ucsb.cs156.frontiers.ControllerTestCase;
 import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.errors.InvalidInstallationTypeException;
+import edu.ucsb.cs156.frontiers.models.RosterStudentDTO;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import edu.ucsb.cs156.frontiers.services.CurrentUserService;
 import edu.ucsb.cs156.frontiers.services.OrganizationLinkerService;
 import lombok.extern.slf4j.Slf4j;
@@ -39,234 +53,296 @@ import lombok.extern.slf4j.Slf4j;
 @AutoConfigureDataJpa
 public class CoursesControllerTests extends ControllerTestCase {
 
-    @MockitoBean
-    private CourseRepository courseRepository;
+        @MockitoBean
+        private CourseRepository courseRepository;
 
-    @Autowired
-    private CurrentUserService currentUserService;
+        @Autowired
+        private CurrentUserService currentUserService;
 
-    @MockitoBean
-    private OrganizationLinkerService linkerService;
+        @MockitoBean
+        private OrganizationLinkerService linkerService;
 
-    /**
-     * Test the POST endpoint
-     */
+        @MockitoBean
+        private UserRepository userRepository;
+
+        @MockitoBean
+        private RosterStudentRepository rosterStudentRepository;
+
+        /**
+         * Test the POST endpoint
+         */
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testPostCourse() throws Exception {
+
+                User user = currentUserService.getCurrentUser().getUser();
+
+                // arrange
+                Course course = Course.builder()
+                                .courseName("CS156")
+                                .orgName("ucsb-cs156-s25")
+                                .term("S25")
+                                .school("UCSB")
+                                .creator(user)
+                                .build();
+
+                when(courseRepository.save(any(Course.class))).thenReturn(course);
+
+                // act
+
+                MvcResult response = mockMvc.perform(post("/api/courses/post")
+                                .with(csrf())
+                                .param("orgName", "ucsb-cs156-s25")
+                                .param("courseName", "CS156")
+                                .param("term", "S25")
+                                .param("school", "UCSB"))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                // assert
+
+                verify(courseRepository, times(1)).save(eq(course));
+
+                String responseString = response.getResponse().getContentAsString();
+                String expectedJson = mapper.writeValueAsString(course);
+                assertEquals(expectedJson, responseString);
+
+        }
+
+        /**
+         * Test the GET endpoint
+         */
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testAllCourses() throws Exception {
+
+                // arrange
+                Course course1 = Course.builder()
+                                .courseName("CS156")
+                                .orgName("ucsb-cs156-s25")
+                                .term("S25")
+                                .school("UCSB")
+                                .build();
+
+                Course course2 = Course.builder()
+                                .courseName("CS148")
+                                .orgName("ucsb-cs148-s25")
+                                .term("S25")
+                                .school("UCSB")
+                                .build();
+
+                when(courseRepository.findAll()).thenReturn(java.util.List.of(course1, course2));
+
+                // act
+
+                MvcResult response = mockMvc.perform(get("/api/courses/all"))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                // assert
+
+                String responseString = response.getResponse().getContentAsString();
+                String expectedJson = mapper.writeValueAsString(java.util.List.of(course1, course2));
+                assertEquals(expectedJson, responseString);
+        }
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testRedirect() throws Exception {
+                doReturn("https://github.com/app/app1").when(linkerService).getRedirectUrl();
+
+                String expectedUrl = "https://github.com/app/app1/installations/new?state=1";
+                MvcResult response = mockMvc.perform(get("/api/courses/redirect")
+                                .param("courseId", "1"))
+                                .andExpect(status().isMovedPermanently())
+                                .andReturn();
+
+                String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
+
+                assertEquals(expectedUrl, responseUrl);
+        }
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testLinkCourseSuccessfully() throws Exception {
+                User user = currentUserService.getCurrentUser().getUser();
+                Course course1 = Course.builder()
+                                .courseName("CS156")
+                                .term("S25")
+                                .school("UCSB")
+                                .creator(user)
+                                .id(1L)
+                                .build();
+                Course course2 = Course.builder()
+                                .courseName("CS156")
+                                .orgName("ucsb-cs156-s25")
+                                .term("S25")
+                                .school("UCSB")
+                                .creator(user)
+                                .installationId("1234")
+                                .orgName("ucsb-cs156-s25")
+                                .id(1L)
+                                .build();
+
+                doReturn(Optional.of(course1)).when(courseRepository).findById(eq(1L));
+                doReturn("ucsb-cs156-s25").when(linkerService).getOrgName("1234");
+                MvcResult response = mockMvc.perform(get("/api/courses/link")
+                                .param("installation_id", "1234")
+                                .param("setup_action", "install")
+                                .param("code", "abcdefg")
+                                .param("state", "1"))
+                                .andExpect(status().isMovedPermanently())
+                                .andReturn();
+
+                String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
+                verify(courseRepository, times(1)).save(eq(course2));
+                assertEquals("/admin/courses?success=True&course=1", responseUrl);
+        }
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testNoPerms() throws Exception {
+
+                MvcResult response = mockMvc.perform(get("/api/courses/link")
+                                .param("setup_action", "request")
+                                .param("code", "abcdefg")
+                                .param("state", "1"))
+                                .andExpect(status().isMovedPermanently())
+                                .andReturn();
+
+                String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
+                assertEquals("/courses/nopermissions", responseUrl);
+        }
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testNotCreator() throws Exception {
+                User separateUser = User.builder().id(2L).build();
+                Course course1 = Course.builder()
+                                .courseName("CS156")
+                                .term("S25")
+                                .school("UCSB")
+                                .creator(separateUser)
+                                .id(1L)
+                                .build();
+
+                doReturn(Optional.of(course1)).when(courseRepository).findById(eq(1L));
+                doReturn("ucsb-cs156-s25").when(linkerService).getOrgName("1234");
+                MvcResult response = mockMvc.perform(get("/api/courses/link")
+                                .param("installation_id", "1234")
+                                .param("setup_action", "install")
+                                .param("code", "abcdefg")
+                                .param("state", "1"))
+                                .andExpect(status().isForbidden())
+                                .andReturn();
+        }
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testCourseLinkNotFound() throws Exception {
+
+                doReturn(Optional.empty()).when(courseRepository).findById(eq(1L));
+                MvcResult response = mockMvc.perform(get("/api/courses/link")
+                                .param("installation_id", "1234")
+                                .param("setup_action", "install")
+                                .param("code", "abcdefg")
+                                .param("state", "1"))
+                                .andExpect(status().isNotFound())
+                                .andReturn();
+                String responseString = response.getResponse().getContentAsString();
+                Map<String, String> expectedMap = Map.of(
+                                "type", "EntityNotFoundException",
+                                "message", "Course with id 1 not found");
+                String expectedJson = mapper.writeValueAsString(expectedMap);
+                assertEquals(expectedJson, responseString);
+        }
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testNotOrganization() throws Exception {
+                User user = currentUserService.getCurrentUser().getUser();
+                Course course1 = Course.builder()
+                                .courseName("CS156")
+                                .term("S25")
+                                .school("UCSB")
+                                .creator(user)
+                                .id(1L)
+                                .build();
+
+                doThrow(new InvalidInstallationTypeException("User")).when(linkerService).getOrgName(eq("1234"));
+                doReturn(Optional.of(course1)).when(courseRepository).findById(eq(1L));
+                MvcResult response = mockMvc.perform(get("/api/courses/link")
+                                .param("installation_id", "1234")
+                                .param("setup_action", "install")
+                                .param("code", "abcdefg")
+                                .param("state", "1"))
+                                .andExpect(status().isBadRequest())
+                                .andReturn();
+
+                String responseString = response.getResponse().getContentAsString();
+                Map<String, String> expectedMap = Map.of(
+                                "type", "InvalidInstallationTypeException",
+                                "message",
+                                "Invalid installation type: User. Frontiers can only be linked to organizations");
+                String expectedJson = mapper.writeValueAsString(expectedMap);
+                assertEquals(expectedJson, responseString);
+        }
+
     @Test
-    @WithMockUser(roles = { "ADMIN" })
-    public void testPostCourse() throws Exception {
+    public void testListCoursesForCurrentUser() throws Exception {
+        String email = "student@example.com";
 
-        User user = currentUserService.getCurrentUser().getUser();
+        OAuth2User principal = Mockito.mock(OAuth2User.class);
+        when(principal.getAttribute("email")).thenReturn(email);
 
+        Authentication auth = new OAuth2AuthenticationToken(
+            principal,
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")),
+            "test-client"
+        );
 
-        // arrange
+        User dbUser = User.builder()
+                         .email(email)
+                         .build();
+        when(userRepository.findByEmail(eq(email)))
+            .thenReturn(Optional.of(dbUser));
+
         Course course = Course.builder()
-                .courseName("CS156")
-                .orgName("ucsb-cs156-s25")
-                .term("S25")
-                .school("UCSB")
-                .creator(user)
-                .build();
+            .id(55L)
+            .installationId("inst-55")
+            .orgName("Test Org")
+            .courseName("Test Course")
+            .term("S25")
+            .school("Engineering")
+            .build();
 
+        RosterStudent rs = new RosterStudent();
+        rs.setId(123L);
+        rs.setCourse(course);
+        rs.setEmail(email);
+        rs.setOrgStatus(OrgStatus.MEMBER);
 
-        when(courseRepository.save(any(Course.class))).thenReturn(course);
+        when(rosterStudentRepository.findAllByEmail(eq(email)))
+            .thenReturn(List.of(rs));
 
-        // act
+        MvcResult result = mockMvc.perform(
+                get("/api/courses/list")
+                .with(authentication(auth))
+            )
+            .andExpect(status().isOk())
+            .andReturn();
 
-        MvcResult response = mockMvc.perform(post("/api/courses/post")
-                .with(csrf())
-                .param("orgName", "ucsb-cs156-s25")
-                .param("courseName", "CS156")
-                .param("term", "S25")
-                .param("school", "UCSB"))
-                .andExpect(status().isOk())
-                .andReturn();
+        Map<String,Object> expected = new LinkedHashMap<>();
+        expected.put("id", course.getId());
+        expected.put("installationId", course.getInstallationId());
+        expected.put("orgName", course.getOrgName());
+        expected.put("courseName", course.getCourseName());
+        expected.put("term", course.getTerm());
+        expected.put("school", course.getSchool());
+        expected.put("studentStatus", RosterStudentDTO.from(rs).getOrgStatus());
 
-        // assert
-
-        verify(courseRepository, times(1)).save(eq(course));
-
-        String responseString = response.getResponse().getContentAsString();
-        String expectedJson = mapper.writeValueAsString(course);
-        assertEquals(expectedJson, responseString);
-
-    }
-
-    /** 
-     * Test the GET endpoint
-     */
-
-    @Test
-    @WithMockUser(roles = { "ADMIN" })
-    public void testAllCourses() throws Exception {
-
-        // arrange
-        Course course1 = Course.builder()
-                .courseName("CS156")
-                .orgName("ucsb-cs156-s25")
-                .term("S25")
-                .school("UCSB")
-                .build();
-
-        Course course2 = Course.builder()
-                .courseName("CS148")
-                .orgName("ucsb-cs148-s25")
-                .term("S25")
-                .school("UCSB")
-                .build();
-
-        when(courseRepository.findAll()).thenReturn(java.util.List.of(course1, course2));
-
-        // act
-
-        MvcResult response = mockMvc.perform(get("/api/courses/all"))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        // assert
-
-        String responseString = response.getResponse().getContentAsString();
-        String expectedJson = mapper.writeValueAsString(java.util.List.of(course1, course2));
-        assertEquals(expectedJson, responseString);
-    }
-
-    @Test
-    @WithMockUser(roles = {"ADMIN"})
-    public void testRedirect() throws Exception {
-        doReturn("https://github.com/app/app1").when(linkerService).getRedirectUrl();
-
-        String expectedUrl = "https://github.com/app/app1/installations/new?state=1";
-        MvcResult response = mockMvc.perform(get("/api/courses/redirect")
-                    .param("courseId", "1"))
-                .andExpect(status().isMovedPermanently())
-                .andReturn();
-
-        String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
-
-        assertEquals(expectedUrl, responseUrl);
-    }
-
-    @Test
-    @WithMockUser(roles = {"ADMIN"})
-    public void testLinkCourseSuccessfully() throws Exception {
-        User user = currentUserService.getCurrentUser().getUser();
-        Course course1 = Course.builder()
-                .courseName("CS156")
-                .term("S25")
-                .school("UCSB")
-                .creator(user)
-                .id(1L)
-                .build();
-        Course course2 = Course.builder()
-                .courseName("CS156")
-                .orgName("ucsb-cs156-s25")
-                .term("S25")
-                .school("UCSB")
-                .creator(user)
-                .installationId("1234")
-                .orgName("ucsb-cs156-s25")
-                .id(1L)
-                .build();
-
-        doReturn(Optional.of(course1)).when(courseRepository).findById(eq(1L));
-        doReturn("ucsb-cs156-s25").when(linkerService).getOrgName("1234");
-        MvcResult response = mockMvc.perform(get("/api/courses/link")
-                .param("installation_id", "1234")
-                .param("setup_action", "install")
-                .param("code", "abcdefg")
-                .param("state", "1"))
-                .andExpect(status().isMovedPermanently())
-                .andReturn();
-
-        String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
-        verify(courseRepository, times(1)).save(eq(course2));
-        assertEquals("/admin/courses?success=True&course=1",  responseUrl);
-    }
-
-    @Test
-    @WithMockUser(roles = {"ADMIN"})
-    public void testNoPerms() throws Exception {
-
-        MvcResult response = mockMvc.perform(get("/api/courses/link")
-                        .param("setup_action", "request")
-                        .param("code", "abcdefg")
-                        .param("state", "1"))
-                .andExpect(status().isMovedPermanently())
-                .andReturn();
-
-        String responseUrl = response.getResponse().getHeader(HttpHeaders.LOCATION);
-        assertEquals("/courses/nopermissions",  responseUrl);
-    }
-
-    @Test
-    @WithMockUser(roles = {"ADMIN"})
-    public void testNotCreator() throws Exception {
-        User separateUser = User.builder().id(2L).build();
-        Course course1 = Course.builder()
-                .courseName("CS156")
-                .term("S25")
-                .school("UCSB")
-                .creator(separateUser)
-                .id(1L)
-                .build();
-
-        doReturn(Optional.of(course1)).when(courseRepository).findById(eq(1L));
-        doReturn("ucsb-cs156-s25").when(linkerService).getOrgName("1234");
-        MvcResult response = mockMvc.perform(get("/api/courses/link")
-                        .param("installation_id", "1234")
-                        .param("setup_action", "install")
-                        .param("code", "abcdefg")
-                        .param("state", "1"))
-                .andExpect(status().isForbidden())
-                .andReturn();
-    }
-
-    @Test
-    @WithMockUser(roles = {"ADMIN"})
-    public void testCourseLinkNotFound() throws Exception {
-
-        doReturn(Optional.empty()).when(courseRepository).findById(eq(1L));
-        MvcResult response = mockMvc.perform(get("/api/courses/link")
-                        .param("installation_id", "1234")
-                        .param("setup_action", "install")
-                        .param("code", "abcdefg")
-                        .param("state", "1"))
-                .andExpect(status().isNotFound())
-                .andReturn();
-        String responseString = response.getResponse().getContentAsString();
-        Map<String, String> expectedMap = Map.of(
-                "type", "EntityNotFoundException",
-                "message", "Course with id 1 not found");
-        String expectedJson = mapper.writeValueAsString(expectedMap);
-        assertEquals(expectedJson, responseString);
-    }
-
-    @Test
-    @WithMockUser(roles = {"ADMIN"})
-    public void testNotOrganization() throws Exception {
-        User user = currentUserService.getCurrentUser().getUser();
-        Course course1 = Course.builder()
-                .courseName("CS156")
-                .term("S25")
-                .school("UCSB")
-                .creator(user)
-                .id(1L)
-                .build();
-
-        doThrow(new InvalidInstallationTypeException("User")).when(linkerService).getOrgName(eq("1234"));
-        doReturn(Optional.of(course1)).when(courseRepository).findById(eq(1L));
-        MvcResult response = mockMvc.perform(get("/api/courses/link")
-                        .param("installation_id", "1234")
-                        .param("setup_action", "install")
-                        .param("code", "abcdefg")
-                        .param("state", "1"))
-                .andExpect(status().isBadRequest())
-                .andReturn();
-
-        String responseString = response.getResponse().getContentAsString();
-        Map<String, String> expectedMap = Map.of(
-                "type", "InvalidInstallationTypeException",
-                "message", "Invalid installation type: User. Frontiers can only be linked to organizations");
-        String expectedJson = mapper.writeValueAsString(expectedMap);
-        assertEquals(expectedJson, responseString);
+        String expectedJson = mapper.writeValueAsString(List.of(expected));
+        assertEquals(expectedJson, result.getResponse().getContentAsString());
     }
 }


### PR DESCRIPTION
Closes #11 

In this PR, I added listCoursesForCurrentUser endpoint for the CoursesController. When a student logs in to the web app, the student could run this function to see which courses they are currently enrolled in and their status in the organization. When a user logs in, he or she gets an id. The endpoint finds the user's email from the OAuth2 authentication principal and use it to find all courses linked to this email in RosterStudentRepository . A list of courses, containing id, installationId, orgName, courseName, term, school, and studentStatus, is returned in DTO format.

You may test it in Swagger in this dokku app: https://frontiers-dev-steven.dokku-07.cs.ucsb.edu/ 
![image](https://github.com/user-attachments/assets/c8ead888-09a6-466a-b3c2-ae13abf116fb)

