### PR TITLE
hz - Create RoleEmailForm component

### DIFF
--- a/frontend/src/main/components/Users/RoleEmailForm.js
+++ b/frontend/src/main/components/Users/RoleEmailForm.js
@@ -1,0 +1,50 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+function RoleEmailForm({ submitAction, buttonLabel = "Create" }) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm();
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "RoleEmailForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="email">Email</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-email"}
+          id="email"
+          type="text"
+          isInvalid={Boolean(errors.email)}
+          {...register("email", {
+            required: "Email is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.email?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default RoleEmailForm;

--- a/frontend/src/main/components/Users/RoleEmailForm.js
+++ b/frontend/src/main/components/Users/RoleEmailForm.js
@@ -15,21 +15,26 @@ function RoleEmailForm({ submitAction, buttonLabel = "Create" }) {
 
   const testIdPrefix = "RoleEmailForm";
 
+  // Stryker disable next-line Regex
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       <Form.Group className="mb-3">
         <Form.Label htmlFor="email">Email</Form.Label>
         <Form.Control
+          // Stryker disable next-line all
           data-testid={testIdPrefix + "-email"}
           id="email"
           type="text"
           isInvalid={Boolean(errors.email)}
           {...register("email", {
             required: "Email is required.",
+            pattern: emailRegex,
           })}
         />
         <Form.Control.Feedback type="invalid">
-          {errors.email?.message}
+          {errors.email && "A valid email is required."}
         </Form.Control.Feedback>
       </Form.Group>
 

--- a/frontend/src/stories/components/Users/RoleEmailForm.stories.js
+++ b/frontend/src/stories/components/Users/RoleEmailForm.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import RoleEmailForm from "main/components/Users/RoleEmailForm";
 
 export default {
-  title: "components/RoleEmail/RoleEmailForm",
+  title: "components/Users/RoleEmailForm",
   component: RoleEmailForm,
 };
 

--- a/frontend/src/stories/components/Users/RoleEmailForm.stories.js
+++ b/frontend/src/stories/components/Users/RoleEmailForm.stories.js
@@ -1,0 +1,21 @@
+import React from "react";
+import RoleEmailForm from "main/components/Users/RoleEmailForm";
+
+export default {
+  title: "components/RoleEmail/RoleEmailForm",
+  component: RoleEmailForm,
+};
+
+const Template = (args) => {
+  return <RoleEmailForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/Users/RoleEmailForm.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailForm.test.js
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import RoleEmailForm from "main/components/Users/RoleEmailForm";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("RoleEmailForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const testId = "RoleEmailForm";
+
+  test("renders correctly", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RoleEmailForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expect(await screen.findByTestId(`${testId}-email`)).toBeInTheDocument();
+    expect(screen.getByText(`Email`)).toBeInTheDocument();
+    expect(await screen.findByTestId(`${testId}-submit`)).toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RoleEmailForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RoleEmailForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Email is required/);
+  });
+});

--- a/frontend/src/tests/components/Users/RoleEmailForm.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailForm.test.js
@@ -62,6 +62,16 @@ describe("RoleEmailForm tests", () => {
     const submitButton = screen.getByText(/Create/);
     fireEvent.click(submitButton);
 
-    await screen.findByText(/Email is required/);
+    await screen.findByText(/A valid email is required./);
+
+    const endInput = screen.getByTestId(`${testId}-email`);
+    fireEvent.change(endInput, { target: { value: "email" } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/A valid email is required./),
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Closes #22 

In this PR, I create a frontend form component to list instructors/admins called RoleEmailForm. It has one field called Email and contains a regular expression check to see if the email entry is valid. This form component can be reused for the Frontend Index Pages for both instructors and admins.

-> View on [Storybook](https://6823eb49391af42ea971678d-bsqdvympvr.chromatic.com/?path=/story/components-users-roleemailform--create)

![image](https://github.com/user-attachments/assets/0f60d129-7abb-46e2-a513-c7c74af8d388)
![image](https://github.com/user-attachments/assets/505cb786-e6e1-4206-b176-8367648796ff)
![image](https://github.com/user-attachments/assets/5e5e221c-8501-40ba-9b88-f6214d695427)

