### PR TITLE
ad - Admin Post and Get Implementation (CRUD operations)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+import jakarta.validation.Valid;
+
+
+import java.time.LocalDateTime;
+
+
+/**
+* This is a REST controller for Admin
+*/
+@Tag(name = "Admin")
+@RequestMapping("/api/admin")
+@RestController
+@Slf4j
+
+public class AdminsController extends ApiController {
+   @Autowired
+   AdminRepository adminRepository;
+
+   /**
+   * Create a new admin
+   * @param adminEmail       the email in typical email format
+   * @return the saved admin
+   */
+  @Operation(summary= "Create a new admin")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public Admin postAdmin(
+          @Parameter(name="email") @RequestParam String email)
+      {
+      
+      Admin admin = new Admin(email);
+      Admin savedAdmin = adminRepository.save(admin);
+      return savedAdmin;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
@@ -62,4 +62,17 @@ public class AdminsController extends ApiController {
       Admin savedAdmin = adminRepository.save(admin);
       return savedAdmin;
   }
+
+  /**
+    * List all admins
+    *
+    * @return an iterable of Admin
+    */
+    @Operation(summary= "List all admins")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<Admin> allAdmins() {
+        Iterable<Admin> admins = adminRepository.findAll();
+        return admins;
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/AdminsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/AdminsControllerTests.java
@@ -1,0 +1,90 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+
+import java.time.LocalDateTime;
+
+
+import java.util.Optional;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@WebMvcTest(controllers = AdminsController.class)
+@Import(TestConfig.class)
+public class AdminsControllerTests extends ControllerTestCase {
+
+
+       @MockBean
+       AdminRepository adminRepository;
+
+
+       @MockBean
+       UserRepository userRepository;
+
+
+       // Authorization tests for post
+
+      @Test
+      public void logged_out_users_cannot_post() throws Exception {
+              mockMvc.perform(post("/api/admin/post"))
+                              .andExpect(status().is(403));
+      }
+
+      @WithMockUser(roles = { "USER" })
+      @Test
+      public void logged_in_regular_users_cannot_post() throws Exception {
+              mockMvc.perform(post("/api/admin/post"))
+                              .andExpect(status().is(403)); // only admins can post
+      }
+
+      // Functionality tests
+
+      @WithMockUser(roles = { "ADMIN", "USER" })
+      @Test
+      public void an_admin_user_can_post_a_new_admin() throws Exception {
+              Admin admin = Admin.builder()
+                              .email("acdamstedt@ucsb.edu")
+                              .build();
+              when(adminRepository.save(eq(admin))).thenReturn(admin);
+              // act
+              MvcResult response = mockMvc.perform(
+                              post("/api/admin/post?email=acdamstedt@ucsb.edu")
+                                              .with(csrf()))
+                              .andExpect(status().isOk()).andReturn();
+              // assert
+              verify(adminRepository, times(1)).save(admin);
+              String expectedJson = mapper.writeValueAsString(admin);
+              String responseString = response.getResponse().getContentAsString();
+              assertEquals(expectedJson, responseString);
+      }
+}


### PR DESCRIPTION
Closes #43
In this PR, I created the Admin Controller and tests file. First, I implemented post with tests, which takes in an email and creates an admin. Next, I implemented get all with tests, which prints all the admins. Both can be tested (on Swagger) at: https://frontiers-dev-acdamstedt.dokku-07.cs.ucsb.edu
<img width="1145" alt="Screenshot 2025-05-19 at 5 17 00 PM" src="https://github.com/user-attachments/assets/96532b1f-46e6-4724-8872-9f0f078904a2" />
<img width="1145" alt="Screenshot 2025-05-19 at 5 16 37 PM" src="https://github.com/user-attachments/assets/aa63be8d-8817-4dac-bfc0-ed6b8f4067b0" />
