### PR TITLE
ad - Admin Delete implementation (CRUD operation) and handle UnsupportedOperationException

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
@@ -16,7 +16,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,12 +28,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
 
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 /**
@@ -75,4 +78,30 @@ public class AdminsController extends ApiController {
         Iterable<Admin> admins = adminRepository.findAll();
         return admins;
     }
+
+    @Value("#{'${app.admin.emails}'.split(',')}")
+    private List<String> adminEmails;
+
+    /**
+    * Delete an Admin
+    *
+    * @param email the email of the admin to delete
+    * @return a message indicating the admin was deleted
+    */
+   @Operation(summary= "Delete an Admin")
+   @PreAuthorize("hasRole('ROLE_ADMIN')")
+   @DeleteMapping("")
+   public Object deleteAdmin(
+           @Parameter(name="email") @RequestParam String email) {
+       Admin admin = adminRepository.findByEmail(email)
+               .orElseThrow(() -> new EntityNotFoundException(Admin.class, email));
+      if (adminEmails.contains(email)) {
+        throw new UnsupportedOperationException("Forbidden to delete an admin from ADMIN_EMAILS list");
+      }
+       adminRepository.delete(admin);
+       return genericMessage("Admin with id %s deleted".formatted(email));
+   }
+
 }
+
+

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+import jakarta.validation.Valid;
+
+
+import java.time.LocalDateTime;
+
+
+/**
+* This is a REST controller for Admin
+*/
+@Tag(name = "Admin")
+@RequestMapping("/api/admin")
+@RestController
+@Slf4j
+
+public class AdminsController extends ApiController {
+   @Autowired
+   AdminRepository adminRepository;
+
+   /**
+   * Create a new admin
+   * @param adminEmail       the email in typical email format
+   * @return the saved admin
+   */
+  @Operation(summary= "Create a new admin")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public Admin postAdmin(
+          @Parameter(name="email") @RequestParam String email)
+      {
+      
+      Admin admin = new Admin(email);
+      Admin savedAdmin = adminRepository.save(admin);
+      return savedAdmin;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
@@ -62,4 +62,17 @@ public class AdminsController extends ApiController {
       Admin savedAdmin = adminRepository.save(admin);
       return savedAdmin;
   }
+
+  /**
+    * List all admins
+    *
+    * @return an iterable of Admin
+    */
+    @Operation(summary= "List all admins")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<Admin> allAdmins() {
+        Iterable<Admin> admins = adminRepository.findAll();
+        return admins;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -67,4 +68,15 @@ public abstract class ApiController {
             "message", e.getMessage()
     );
   }
+
+  /**
+   * This method handles the UnsupportedOperationException.
+   * @param e the exception
+   * @return a map with the type and message of the exception
+   */
+    @ExceptionHandler(UnsupportedOperationException.class)
+    public ResponseEntity<Map<String, String>> handleUnsupportedOperation(UnsupportedOperationException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(Map.of("message", ex.getMessage()));
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/AdminsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/AdminsControllerTests.java
@@ -1,0 +1,90 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+
+import java.time.LocalDateTime;
+
+
+import java.util.Optional;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@WebMvcTest(controllers = AdminsController.class)
+@Import(TestConfig.class)
+public class AdminsControllerTests extends ControllerTestCase {
+
+
+       @MockBean
+       AdminRepository adminRepository;
+
+
+       @MockBean
+       UserRepository userRepository;
+
+
+       // Authorization tests for post
+
+      @Test
+      public void logged_out_users_cannot_post() throws Exception {
+              mockMvc.perform(post("/api/admin/post"))
+                              .andExpect(status().is(403));
+      }
+
+      @WithMockUser(roles = { "USER" })
+      @Test
+      public void logged_in_regular_users_cannot_post() throws Exception {
+              mockMvc.perform(post("/api/admin/post"))
+                              .andExpect(status().is(403)); // only admins can post
+      }
+
+      // Functionality tests
+
+      @WithMockUser(roles = { "ADMIN", "USER" })
+      @Test
+      public void an_admin_user_can_post_a_new_admin() throws Exception {
+              Admin admin = Admin.builder()
+                              .email("acdamstedt@ucsb.edu")
+                              .build();
+              when(adminRepository.save(eq(admin))).thenReturn(admin);
+              // act
+              MvcResult response = mockMvc.perform(
+                              post("/api/admin/post?email=acdamstedt@ucsb.edu")
+                                              .with(csrf()))
+                              .andExpect(status().isOk()).andReturn();
+              // assert
+              verify(adminRepository, times(1)).save(admin);
+              String expectedJson = mapper.writeValueAsString(admin);
+              String responseString = response.getResponse().getContentAsString();
+              assertEquals(expectedJson, responseString);
+      }
+}


### PR DESCRIPTION
Closes #15 
In this PR, I implemented the Delete function for Admin. It takes in an email, working as the id, and deletes it. If the email doesn't exist or is an email in ADMIN_EMAILS, it throws an error and the delete does not occur. The exception for not deleting an email from ADMIN_EMAILS had to be handled in ApiController so it threw a 403 error like the description of the task expected. 
This can be tested at: https://frontiers-dev-acdamstedt.dokku-07.cs.ucsb.edu/. You have to create your admin email in the POST function before you can try to delete it.
<img width="1154" alt="Screenshot 2025-05-20 at 2 49 01 PM" src="https://github.com/user-attachments/assets/03091c17-c0f6-4e63-bdcd-d617048cdd68" />
<img width="1157" alt="Screenshot 2025-05-20 at 2 49 44 PM" src="https://github.com/user-attachments/assets/00da8287-8540-42d0-b26c-ddaae22c9d46" />
