### PR TITLE
pc - try a simpler version of handling deleting roster student

### DIFF
--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -1208,38 +1208,6 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                         response.getResponse().getContentAsString());
         }
 
-        // @Test
-        // @WithMockUser(roles = { "ADMIN" })
-        // public void testDeleteRosterStudent_nullStudentsList() throws Exception {
-        //         RosterStudent rosterStudent = RosterStudent.builder()
-        //                 .id(1L)
-        //                 .firstName("Test")
-        //                 .lastName("Student")
-        //                 .studentId("A123456")
-        //                 .email("test@ucsb.edu")
-        //                 .course(course1)
-        //                 .rosterStatus(RosterStatus.ROSTER)
-        //                 .orgStatus(OrgStatus.NONE)
-        //                 .build();
-
-        //         course1.setRosterStudents(null);
-
-        //         when(rosterStudentRepository.findById(eq(1L))).thenReturn(Optional.of(rosterStudent));
-
-        //         MvcResult response = mockMvc.perform(delete("/api/rosterstudents/delete")
-        //                 .with(csrf())
-        //                 .param("id", "1"))
-        //                 .andExpect(status().isOk())
-        //                 .andReturn();
-
-        //         verify(rosterStudentRepository).findById(eq(1L));
-        //         verify(rosterStudentRepository).delete(eq(rosterStudent));
-        //         verify(courseRepository, never()).save(any(Course.class));
-
-        //         assertEquals("Successfully deleted roster student and removed him/her from the course list", 
-        //                 response.getResponse().getContentAsString());
-        // }
-
         @Test
         @WithMockUser(roles = { "USER" })
         public void testDeleteRosterStudent_unauthorized() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -1149,8 +1149,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 verify(rosterStudentRepository).findById(eq(1L));
                 verify(courseRepository).save(any(Course.class));
                 verify(rosterStudentRepository).delete(eq(rosterStudent));
-                verify(studentsSpy).clear();
-                verify(studentsSpy).addAll(anyList());
+                verify(studentsSpy).remove(eq(rosterStudent));
 
                 assertEquals("Successfully deleted roster student and removed him/her from the course list", 
                         response.getResponse().getContentAsString());
@@ -1209,37 +1208,37 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                         response.getResponse().getContentAsString());
         }
 
-        @Test
-        @WithMockUser(roles = { "ADMIN" })
-        public void testDeleteRosterStudent_nullStudentsList() throws Exception {
-                RosterStudent rosterStudent = RosterStudent.builder()
-                        .id(1L)
-                        .firstName("Test")
-                        .lastName("Student")
-                        .studentId("A123456")
-                        .email("test@ucsb.edu")
-                        .course(course1)
-                        .rosterStatus(RosterStatus.ROSTER)
-                        .orgStatus(OrgStatus.NONE)
-                        .build();
+        // @Test
+        // @WithMockUser(roles = { "ADMIN" })
+        // public void testDeleteRosterStudent_nullStudentsList() throws Exception {
+        //         RosterStudent rosterStudent = RosterStudent.builder()
+        //                 .id(1L)
+        //                 .firstName("Test")
+        //                 .lastName("Student")
+        //                 .studentId("A123456")
+        //                 .email("test@ucsb.edu")
+        //                 .course(course1)
+        //                 .rosterStatus(RosterStatus.ROSTER)
+        //                 .orgStatus(OrgStatus.NONE)
+        //                 .build();
 
-                course1.setRosterStudents(null);
+        //         course1.setRosterStudents(null);
 
-                when(rosterStudentRepository.findById(eq(1L))).thenReturn(Optional.of(rosterStudent));
+        //         when(rosterStudentRepository.findById(eq(1L))).thenReturn(Optional.of(rosterStudent));
 
-                MvcResult response = mockMvc.perform(delete("/api/rosterstudents/delete")
-                        .with(csrf())
-                        .param("id", "1"))
-                        .andExpect(status().isOk())
-                        .andReturn();
+        //         MvcResult response = mockMvc.perform(delete("/api/rosterstudents/delete")
+        //                 .with(csrf())
+        //                 .param("id", "1"))
+        //                 .andExpect(status().isOk())
+        //                 .andReturn();
 
-                verify(rosterStudentRepository).findById(eq(1L));
-                verify(rosterStudentRepository).delete(eq(rosterStudent));
-                verify(courseRepository, never()).save(any(Course.class));
+        //         verify(rosterStudentRepository).findById(eq(1L));
+        //         verify(rosterStudentRepository).delete(eq(rosterStudent));
+        //         verify(courseRepository, never()).save(any(Course.class));
 
-                assertEquals("Successfully deleted roster student and removed him/her from the course list", 
-                        response.getResponse().getContentAsString());
-        }
+        //         assertEquals("Successfully deleted roster student and removed him/her from the course list", 
+        //                 response.getResponse().getContentAsString());
+        // }
 
         @Test
         @WithMockUser(roles = { "USER" })


### PR DESCRIPTION
This draft PR proposes a simpler way of handling the code for deleting roster students.

It still has some commented out code in one of the tests; that would need to be deleted before merging into main; I'm keeping that for now so that you can see more clearly what was deleted (and in case I was wrong and we need to bring that back.)