### PR TITLE
hz - fix error message for First Name field in RosterStudentForm

### DIFF
--- a/frontend/src/main/components/RosterStudent/RosterStudentForm.js
+++ b/frontend/src/main/components/RosterStudent/RosterStudentForm.js
@@ -43,7 +43,7 @@ function RosterStudentForm({
           data-testid={testIdPrefix + "-firstName"}
           id="firstName"
           type="text"
-          isInvalid={Boolean(errors.orgTranslationShort)}
+          isInvalid={Boolean(errors.firstName)}
           {...register("firstName", {
             required: "First Name is required.",
           })}


### PR DESCRIPTION
In this PR, I fix the error message for the First Name field in the roster students form component.

-> Test on [Storybook](https://6823eb49391af42ea971678d-awwrggmhss.chromatic.com/?path=/story/components-rosterstudent-rosterstudentform--create)

Old form:
![image](https://github.com/user-attachments/assets/8d6b3dde-f3d2-42b5-8c70-a46768e70705)

Revised form:
![image](https://github.com/user-attachments/assets/ddf982c9-9aba-44e4-965b-f522cc0799a7)
