### PR TITLE
sz-create webhook listener for github org invite and add member

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -213,11 +213,11 @@ public class RosterStudentsController extends ApiController {
         RosterStudent rosterStudent = rosterStudentRepository.findById(rosterStudentId)
                 .orElseThrow(() -> new EntityNotFoundException(RosterStudent.class, rosterStudentId));
 
-        if (currentUser.getId() != rosterStudent.getUser().getId()) {
+        if (rosterStudent.getUser() == null || currentUser.getId() != rosterStudent.getUser().getId()) {
             throw new AccessDeniedException("User not authorized to link this roster student");
         }
 
-        if (rosterStudent.getGithubId() != 0 && rosterStudent.getGithubLogin() != null ) {
+        if ((rosterStudent.getGithubId() != null && rosterStudent.getGithubId() != 0) && rosterStudent.getGithubLogin() != null) {
             return ResponseEntity.badRequest().body("This roster student is already linked to a GitHub account");
         }
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -47,24 +47,30 @@ public class WebhookController {
             
             // Handle member_added and member_invited events
             if(action.equals("member_added") || action.equals("member_invited")){
-                String githubLogin = jsonBody.get("membership").get("user").get("login").asText();
-                String installationId = jsonBody.get("installation").get("id").asText();
-                Optional<Course> course = courseRepository.findByInstallationId(installationId);
-                
-                if(course.isPresent()){
-                    Optional<RosterStudent> student = rosterStudentRepository.findByCourseAndGithubLogin(course.get(), githubLogin);
-                    if(student.isPresent()){
-                        RosterStudent updatedStudent = student.get();
-                        
-                        // Update status based on action
-                        if(action.equals("member_added")) {
-                            updatedStudent.setOrgStatus(OrgStatus.MEMBER);
-                        } else if(action.equals("member_invited")) {
-                            updatedStudent.setOrgStatus(OrgStatus.INVITED);
+                // Add null checks for each level of the JSON structure
+                if (jsonBody.has("membership") && jsonBody.get("membership").has("user") && 
+                    jsonBody.get("membership").get("user").has("login") && 
+                    jsonBody.has("installation") && jsonBody.get("installation").has("id")) {
+                    
+                    String githubLogin = jsonBody.get("membership").get("user").get("login").asText();
+                    String installationId = jsonBody.get("installation").get("id").asText();
+                    Optional<Course> course = courseRepository.findByInstallationId(installationId);
+                    
+                    if(course.isPresent()){
+                        Optional<RosterStudent> student = rosterStudentRepository.findByCourseAndGithubLogin(course.get(), githubLogin);
+                        if(student.isPresent()){
+                            RosterStudent updatedStudent = student.get();
+                            
+                            // Update status based on action
+                            if(action.equals("member_added")) {
+                                updatedStudent.setOrgStatus(OrgStatus.MEMBER);
+                            } else if(action.equals("member_invited")) {
+                                updatedStudent.setOrgStatus(OrgStatus.INVITED);
+                            }
+                            
+                            rosterStudentRepository.save(updatedStudent);
+                            return ResponseEntity.ok(updatedStudent.toString());
                         }
-                        
-                        rosterStudentRepository.save(updatedStudent);
-                        return ResponseEntity.ok(updatedStudent.toString());
                     }
                 }
             }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -51,12 +51,11 @@ public class WebhookController {
             
             // Handle member_added and member_invited events
             if(action.equals("member_added") || action.equals("member_invited")){
-                // Add null checks for each level of the JSON structure
-                if (jsonBody.has("membership") && jsonBody.get("membership").has("user") && 
-                    jsonBody.get("membership").get("user").has("login") && 
+                // Based on the actual payload structure
+                if (jsonBody.has("user") && jsonBody.get("user").has("login") && 
                     jsonBody.has("installation") && jsonBody.get("installation").has("id")) {
                     
-                    String githubLogin = jsonBody.get("membership").get("user").get("login").asText();
+                    String githubLogin = jsonBody.get("user").get("login").asText();
                     String installationId = jsonBody.get("installation").get("id").asText();
                     log.info("GitHub login: {}, Installation ID: {}", githubLogin, installationId);
                     

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -45,73 +45,80 @@ public class WebhookController {
     public ResponseEntity<String> createGitHubWebhook(@RequestBody JsonNode jsonBody) throws JsonProcessingException {
         log.info("Received GitHub webhook: {}", jsonBody.toString());
 
-        if(jsonBody.has("action")){
-            String action = jsonBody.get("action").asText();
-            log.info("Webhook action: {}", action);
-            
-            // Handle member_added and member_invited events
-            if(action.equals("member_added") || action.equals("member_invited")){
-                // Extract GitHub login based on payload structure
-                String githubLogin = null;
-                String installationId = null;
-                
-                // For member_added events, the structure is different
-                if (action.equals("member_added") && jsonBody.has("membership") && 
-                    jsonBody.get("membership").has("user") && 
-                    jsonBody.get("membership").get("user").has("login") &&
-                    jsonBody.has("installation") && 
-                    jsonBody.get("installation").has("id")) {
-                    
-                    githubLogin = jsonBody.get("membership").get("user").get("login").asText();
-                    installationId = jsonBody.get("installation").get("id").asText();
-                } 
-                // For member_invited events, use the original structure
-                else if (action.equals("member_invited") && 
-                         jsonBody.has("user") && jsonBody.get("user").has("login") && 
-                         jsonBody.has("installation") && jsonBody.get("installation").has("id")) {
-                    
-                    githubLogin = jsonBody.get("user").get("login").asText();
-                    installationId = jsonBody.get("installation").get("id").asText();
-                }
-                
-                if (githubLogin != null && installationId != null) {
-                    log.info("GitHub login: {}, Installation ID: {}", githubLogin, installationId);
-                    
-                    Optional<Course> course = courseRepository.findByInstallationId(installationId);
-                    log.info("Course found: {}", course.isPresent());
-                    
-                    if(course.isPresent()){
-                        Optional<RosterStudent> student = rosterStudentRepository.findByCourseAndGithubLogin(course.get(), githubLogin);
-                        log.info("Student found: {}", student.isPresent());
-                        
-                        if(student.isPresent()){
-                            RosterStudent updatedStudent = student.get();
-                            log.info("Current student org status: {}", updatedStudent.getOrgStatus());
-                            
-                            // Update status based on action
-                            if(action.equals("member_added")) {
-                                updatedStudent.setOrgStatus(OrgStatus.MEMBER);
-                                log.info("Setting status to MEMBER");
-                            } else if(action.equals("member_invited")) {
-                                updatedStudent.setOrgStatus(OrgStatus.INVITED);
-                                log.info("Setting status to INVITED");
-                            }
-                            
-                            rosterStudentRepository.save(updatedStudent);
-                            log.info("Student saved with new org status: {}", updatedStudent.getOrgStatus());
-                            return ResponseEntity.ok(updatedStudent.toString());
-                        } else {
-                            log.warn("No student found with GitHub login: {} in course: {}", githubLogin, course.get().getCourseName());
-                        }
-                    } else {
-                        log.warn("No course found with installation ID: {}", installationId);
-                    }
-                } else {
-                    log.warn("Webhook missing required fields for processing");
-                }
-            }
+        if(!jsonBody.has("action")){
+            return ResponseEntity.ok().body("success");
         }
         
-        return ResponseEntity.ok().body("success");
+        String action = jsonBody.get("action").asText();
+        log.info("Webhook action: {}", action);
+        
+        // Early return if not an action we care about
+        if(!action.equals("member_added") && !action.equals("member_invited")) {
+            return ResponseEntity.ok().body("success");
+        }
+        
+        // Extract GitHub login based on payload structure
+        String githubLogin = null;
+        String installationId = null;
+        
+        // For member_added events, the structure is different
+        if (action.equals("member_added")) {
+            if (!jsonBody.has("membership") || 
+                !jsonBody.get("membership").has("user") || 
+                !jsonBody.get("membership").get("user").has("login") ||
+                !jsonBody.has("installation") || 
+                !jsonBody.get("installation").has("id")) {
+                return ResponseEntity.ok().body("success");
+            }
+            
+            githubLogin = jsonBody.get("membership").get("user").get("login").asText();
+            installationId = jsonBody.get("installation").get("id").asText();
+        } 
+        // For member_invited events, use the original structure
+        else { // must be "member_invited" based on earlier check
+            if (!jsonBody.has("user") || 
+                !jsonBody.get("user").has("login") || 
+                !jsonBody.has("installation") || 
+                !jsonBody.get("installation").has("id")) {
+                return ResponseEntity.ok().body("success");
+            }
+            
+            githubLogin = jsonBody.get("user").get("login").asText();
+            installationId = jsonBody.get("installation").get("id").asText();
+        }
+        
+        log.info("GitHub login: {}, Installation ID: {}", githubLogin, installationId);
+        
+        Optional<Course> course = courseRepository.findByInstallationId(installationId);
+        log.info("Course found: {}", course.isPresent());
+        
+        if(!course.isPresent()){
+            log.warn("No course found with installation ID: {}", installationId);
+            return ResponseEntity.ok().body("success");
+        }
+        
+        Optional<RosterStudent> student = rosterStudentRepository.findByCourseAndGithubLogin(course.get(), githubLogin);
+        log.info("Student found: {}", student.isPresent());
+        
+        if(!student.isPresent()){
+            log.warn("No student found with GitHub login: {} in course: {}", githubLogin, course.get().getCourseName());
+            return ResponseEntity.ok().body("success");
+        }
+        
+        RosterStudent updatedStudent = student.get();
+        log.info("Current student org status: {}", updatedStudent.getOrgStatus());
+        
+        // Update status based on action
+        if(action.equals("member_added")) {
+            updatedStudent.setOrgStatus(OrgStatus.MEMBER);
+            log.info("Setting status to MEMBER");
+        } else { // must be "member_invited" based on earlier check
+            updatedStudent.setOrgStatus(OrgStatus.INVITED);
+            log.info("Setting status to INVITED");
+        }
+        
+        rosterStudentRepository.save(updatedStudent);
+        log.info("Student saved with new org status: {}", updatedStudent.getOrgStatus());
+        return ResponseEntity.ok(updatedStudent.toString());
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -51,12 +51,30 @@ public class WebhookController {
             
             // Handle member_added and member_invited events
             if(action.equals("member_added") || action.equals("member_invited")){
-                // Based on the actual payload structure
-                if (jsonBody.has("user") && jsonBody.get("user").has("login") && 
-                    jsonBody.has("installation") && jsonBody.get("installation").has("id")) {
+                // Extract GitHub login based on payload structure
+                String githubLogin = null;
+                String installationId = null;
+                
+                // For member_added events, the structure is different
+                if (action.equals("member_added") && jsonBody.has("membership") && 
+                    jsonBody.get("membership").has("user") && 
+                    jsonBody.get("membership").get("user").has("login") &&
+                    jsonBody.has("installation") && 
+                    jsonBody.get("installation").has("id")) {
                     
-                    String githubLogin = jsonBody.get("user").get("login").asText();
-                    String installationId = jsonBody.get("installation").get("id").asText();
+                    githubLogin = jsonBody.get("membership").get("user").get("login").asText();
+                    installationId = jsonBody.get("installation").get("id").asText();
+                } 
+                // For member_invited events, use the original structure
+                else if (action.equals("member_invited") && 
+                         jsonBody.has("user") && jsonBody.get("user").has("login") && 
+                         jsonBody.has("installation") && jsonBody.get("installation").has("id")) {
+                    
+                    githubLogin = jsonBody.get("user").get("login").asText();
+                    installationId = jsonBody.get("installation").get("id").asText();
+                }
+                
+                if (githubLogin != null && installationId != null) {
                     log.info("GitHub login: {}, Installation ID: {}", githubLogin, installationId);
                     
                     Optional<Course> course = courseRepository.findByInstallationId(installationId);

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/WebhookController.java
@@ -11,6 +11,7 @@ import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +23,7 @@ import java.util.Optional;
 @Tag(name = "Webhooks Controller")
 @RestController
 @RequestMapping("/api/webhooks")
+@Slf4j
 public class WebhookController {
 
 
@@ -41,9 +43,11 @@ public class WebhookController {
     */
     @PostMapping("/github")
     public ResponseEntity<String> createGitHubWebhook(@RequestBody JsonNode jsonBody) throws JsonProcessingException {
+        log.info("Received GitHub webhook: {}", jsonBody.toString());
 
         if(jsonBody.has("action")){
             String action = jsonBody.get("action").asText();
+            log.info("Webhook action: {}", action);
             
             // Handle member_added and member_invited events
             if(action.equals("member_added") || action.equals("member_invited")){
@@ -54,24 +58,39 @@ public class WebhookController {
                     
                     String githubLogin = jsonBody.get("membership").get("user").get("login").asText();
                     String installationId = jsonBody.get("installation").get("id").asText();
+                    log.info("GitHub login: {}, Installation ID: {}", githubLogin, installationId);
+                    
                     Optional<Course> course = courseRepository.findByInstallationId(installationId);
+                    log.info("Course found: {}", course.isPresent());
                     
                     if(course.isPresent()){
                         Optional<RosterStudent> student = rosterStudentRepository.findByCourseAndGithubLogin(course.get(), githubLogin);
+                        log.info("Student found: {}", student.isPresent());
+                        
                         if(student.isPresent()){
                             RosterStudent updatedStudent = student.get();
+                            log.info("Current student org status: {}", updatedStudent.getOrgStatus());
                             
                             // Update status based on action
                             if(action.equals("member_added")) {
                                 updatedStudent.setOrgStatus(OrgStatus.MEMBER);
+                                log.info("Setting status to MEMBER");
                             } else if(action.equals("member_invited")) {
                                 updatedStudent.setOrgStatus(OrgStatus.INVITED);
+                                log.info("Setting status to INVITED");
                             }
                             
                             rosterStudentRepository.save(updatedStudent);
+                            log.info("Student saved with new org status: {}", updatedStudent.getOrgStatus());
                             return ResponseEntity.ok(updatedStudent.toString());
+                        } else {
+                            log.warn("No student found with GitHub login: {} in course: {}", githubLogin, course.get().getCourseName());
                         }
+                    } else {
+                        log.warn("No course found with installation ID: {}", installationId);
                     }
+                } else {
+                    log.warn("Webhook missing required fields for processing");
                 }
             }
         }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/WebhookControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/WebhookControllerTests.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Optional;
 
@@ -134,7 +135,7 @@ public class WebhookControllerTests extends ControllerTestCase {
     public void action_wrong() throws Exception {
         String sendBody = """
                 {
-                "action" : "member_invited",
+                "action" : "member_removed",
                 "membership": {
                     "user": {
                         "login": "testLogin"
@@ -180,6 +181,361 @@ public class WebhookControllerTests extends ControllerTestCase {
                 .andReturn();
         verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
         verify(courseRepository, times(0)).findByInstallationId(contains("1234"));
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void successfulWebhook_memberInvited() throws Exception {
+        Course course = Course.builder().installationId("1234").build();
+        RosterStudent student = RosterStudent.builder().githubLogin("testLogin").course(course).build();
+        RosterStudent updated = RosterStudent.builder().githubLogin("testLogin").course(course).orgStatus(OrgStatus.INVITED).build();
+
+        // Create argument captor to capture the actual student being saved
+        ArgumentCaptor<RosterStudent> studentCaptor = ArgumentCaptor.forClass(RosterStudent.class);
+        
+        doReturn(Optional.of(course)).when(courseRepository).findByInstallationId(contains("1234"));
+        doReturn(Optional.of(student)).when(rosterStudentRepository).findByCourseAndGithubLogin(eq(course), contains("testLogin"));
+        doReturn(updated).when(rosterStudentRepository).save(studentCaptor.capture());
+
+        String sendBody = """
+                {
+                "action" : "member_invited",
+                "user": {
+                    "login": "testLogin"
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                .content(sendBody)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        
+        // Verify the methods were called
+        verify(rosterStudentRepository, times(1)).findByCourseAndGithubLogin(eq(course), contains("testLogin"));
+        verify(courseRepository, times(1)).findByInstallationId(contains("1234"));
+        verify(rosterStudentRepository, times(1)).save(any(RosterStudent.class));
+        
+        // Verify that the status was set to INVITED
+        assertEquals(OrgStatus.INVITED, studentCaptor.getValue().getOrgStatus());
+        
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals(updated.toString(), actualBody);
+    }
+
+    @Test
+    public void memberAdded_missingMembershipField() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void memberAdded_missingUserField() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "membership": {
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void memberAdded_missingLoginField() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "membership": {
+                    "user": {
+                    }
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void memberAdded_missingInstallationField() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void memberAdded_missingInstallationIdField() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                },
+                "installation":{
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void memberInvited_missingUserField() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_invited",
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void memberInvited_missingLoginField() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_invited",
+                "user": {
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void memberInvited_missingInstallationField() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_invited",
+                "user": {
+                    "login": "testLogin"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void memberInvited_missingInstallationIdField() throws Exception {
+        String sendBody = """
+                {
+                "action" : "member_invited",
+                "user": {
+                    "login": "testLogin"
+                },
+                "installation":{
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void testUnrecognizedAction_withValidFields() throws Exception {
+        String sendBody = """
+                {
+                "action" : "some_other_action",
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void testNullGithubLoginAndInstallationId() throws Exception {
+        // This test creates a situation where the action is recognized but the extraction
+        // of githubLogin and installationId fails in an unexpected way
+        String sendBody = """
+                {
+                "action" : "member_added",
+                "membership": {
+                    "user": {
+                        "not_login": "testLogin"
+                    }
+                },
+                "installation":{
+                    "not_id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
+        verify(rosterStudentRepository, times(0)).save(any());
+        String actualBody = response.getResponse().getContentAsString();
+        assertEquals("success", actualBody);
+    }
+
+    @Test
+    public void testMemberRemoved_withValidFields() throws Exception {
+        // This test creates a situation where we have a valid action that's not handled
+        // but all fields are present, to test the specific branch where githubLogin and installationId
+        // are extracted but the action isn't one we process further
+        String sendBody = """
+                {
+                "action" : "member_removed",
+                "membership": {
+                    "user": {
+                        "login": "testLogin"
+                    }
+                },
+                "installation":{
+                    "id": "1234"
+                }
+                }
+                """;
+
+        MvcResult response = mockMvc.perform(post("/api/webhooks/github")
+                        .content(sendBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        verify(rosterStudentRepository, times(0)).findByCourseAndGithubLogin(any(), any());
+        verify(courseRepository, times(0)).findByInstallationId(any());
         verify(rosterStudentRepository, times(0)).save(any());
         String actualBody = response.getResponse().getContentAsString();
         assertEquals("success", actualBody);


### PR DESCRIPTION
Closes #5 

This PR implements a webhook listener for GitHub organization membership events that allows the application to track when students are invited to or join a course's GitHub organization.

Dokku deployment: https://frontier-zhushelly.dokku-07.cs.ucsb.edu/

To test this PR, two people are needed, tester1 and tester2. tester1 is the main tester. 

**Step 1:** tester1 should go on the deployed app and create a course by using the endpoint POST /api/courses/post.
The fields could be arbitrary, such as: 
<img width="845" alt="Screenshot 2025-05-21 at 18 40 40" src="https://github.com/user-attachments/assets/efa250c6-7339-4abd-bd23-48f857021140" />
Then you should get a response body like this:
{
  "id": 2,
  "installationId": null,
  "orgName": "testorg",
  "courseName": "testcourse",
  "term": "sp25",
  "school": "ucsb"
} 
This courseId (in this case, 2) will be used as reference in the future. 

**Step 2:** tester1 should go to Github and create a new Github organization. You may name this username-testorg1 or something similar. Free plan is sufficient. 
<img width="1436" alt="Screenshot 2025-05-21 at 18 45 32" src="https://github.com/user-attachments/assets/17a1f855-1ea6-4dbc-ad70-81c439304950" />

**Step 3:** tester1 should visit the dokku app and go to Admin > Courses.
Then for the course you just created, click "Install Github App" and select the Github organization you created to link them together. You should see Installation Id field to be filled after this. 
<img width="1352" alt="Screenshot 2025-05-21 at 18 46 59" src="https://github.com/user-attachments/assets/7cb58312-c471-43c2-b546-ae097571e683" />

**Step 4:** tester1 should create a RosterStudent in this course by using the endpoint POST /api/rosterstudents/post
<img width="855" alt="Screenshot 2025-05-21 at 18 50 45" src="https://github.com/user-attachments/assets/21cc199f-1ac9-4a6e-8855-d60d7ba6971f" />
studentId, firstName, lastName could be arbitrary, but email should be tester2's email that is linked to their Github account. And courseId should be the id of the course you just created (in this case, 2). 
You should get a response body like this:
{
  "id": 16,
  "course": {
    "id": 2,
    "installationId": "67793410",
    "orgName": "zhushelly-testorg2",
    "courseName": "testcourse",
    "term": "sp25",
    "school": "ucsb"
  },
  "studentId": "1234567",
  "firstName": "tester_lastname",
  "lastName": "tester_lastname",
  "email": "tester2@ucsb.edu",
  "user": null,
  "rosterStatus": "MANUAL",
  "orgStatus": "NONE",
  "githubId": null,
  "githubLogin": null
}
This id (in this case, 16) will be used in the next step. 

**Step 5:** Now tester2 should go to the dokku app. Login and connect to Github. Then, use the endpoint PUT api/rosterstudents/linkGitHub to link the roster student to their Github. 
<img width="750" alt="Screenshot 2025-05-21 at 18 54 45" src="https://github.com/user-attachments/assets/65dbe24b-b81c-4e00-bd12-468df144feaa" />
Execute this by entering your rosterStudentId from the last step (in this case, 16). 

**Step 6:** tester1 should go to the Github organization and invite tester2 as a member.
<img width="1419" alt="Screenshot 2025-05-21 at 18 57 03" src="https://github.com/user-attachments/assets/b42a9775-bfed-4cad-845e-79fac3ff4e35" />

**Step 7:** tester1 can now go to Swagger endpoint GET /api/rosterstudents/course and execute it by entering the courseId (in this case, 2). tester1 should be able to see that the "orgStatus" field of the invited student to be changed to "INVITED." In the image shown, it's still "NONE" before the invite.
<img width="493" alt="Screenshot 2025-05-21 at 19 02 29" src="https://github.com/user-attachments/assets/31982e49-07c7-45a0-a711-6966c7b4df75" />

**Step 8:** tester2 should accept the Github organization invite in their email. Now, tester1 should be able to see the "orgStatus" field of the invited student to be changed to "MEMBER."
<img width="937" alt="Screenshot 2025-05-21 at 19 02 15" src="https://github.com/user-attachments/assets/e5e868f8-fdf8-45b1-b522-6d5fb7237367" />

