### PR TITLE
ad - ADMIN_EMAILS are added to the admins table at startup

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunner.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunner.java
@@ -1,0 +1,23 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/** This class contains a `run` method that is called once at application startup time. */
+@Slf4j
+@Configuration
+public class FrontiersApplicationRunner implements ApplicationRunner {
+
+  @Autowired FrontiersStartup frontiersStartup;
+
+  /** Called once at application startup time*/
+  @Override
+  public void run(ApplicationArguments args) throws Exception {
+    log.info("FrontiersApplicationRunner.run called");
+    frontiersStartup.alwaysRunOnStartup();
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartup.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartup.java
@@ -19,8 +19,8 @@ import edu.ucsb.cs156.frontiers.services.jobs.JobContextConsumer;
 public class FrontiersStartup {
 
     @Value("#{'${app.admin.emails}'.split(',')}")
-    private List<String> adminEmails;
-    @Autowired private AdminRepository adminRepository;
+    List<String> adminEmails;
+    @Autowired AdminRepository adminRepository;
 
   /**
    * Called once at application startup time . Put code here if you want it to run once each time

--- a/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartup.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartup.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+
+import edu.ucsb.cs156.frontiers.services.jobs.JobContextConsumer;
+
+/** This class contains a `run` method that is called once at application startup time. */
+@Slf4j
+@Component
+public class FrontiersStartup {
+
+    @Value("#{'${app.admin.emails}'.split(',')}")
+    private List<String> adminEmails;
+    @Autowired private AdminRepository adminRepository;
+
+  /**
+   * Called once at application startup time . Put code here if you want it to run once each time
+   * the Spring Boot application starts up in all environments.
+   */
+  public void alwaysRunOnStartup() {
+    log.info("alwaysRunOnStartup called");
+    try {
+      adminEmails.forEach(
+        (email) -> {
+          Admin admin = new Admin(email);
+          adminRepository.save(admin);
+        }
+      );
+    } catch (Exception e) {
+      log.error("Error in loading all ADMIN_EMAILS:", e);
+    }
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunnerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunnerTests.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.ApplicationArguments;
+
+import static org.mockito.Mockito.*;
+
+class FrontiersApplicationRunnerTests {
+
+    private FrontiersApplicationRunner frontiersApplicationRunner;
+
+    @Mock
+    private FrontiersStartup frontiersStartup;
+
+    @Mock
+    private ApplicationArguments mockArgs;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        frontiersApplicationRunner = new FrontiersApplicationRunner();
+        frontiersApplicationRunner.frontiersStartup = frontiersStartup; // Manually inject mock
+    }
+
+    @Test
+    void test_run_calls_AlwaysRunOnStartup() throws Exception {
+        frontiersApplicationRunner.run(mockArgs);
+        verify(frontiersStartup, times(1)).alwaysRunOnStartup();
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartupTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartupTests.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+class FrontiersStartupTests {
+
+    @Mock
+    private AdminRepository adminRepository;
+
+    private FrontiersStartup frontiersStartup;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        frontiersStartup = new FrontiersStartup();
+        frontiersStartup.adminRepository = adminRepository;
+        frontiersStartup.adminEmails = List.of("acdamstedt@ucsb.edu", "phtcon@ucsb.edu");
+    }
+
+    @Test
+    void test_AlwaysRunOnStartup_saves_admins() {
+        frontiersStartup.alwaysRunOnStartup();
+
+        verify(adminRepository).save(new Admin("acdamstedt@ucsb.edu"));
+        verify(adminRepository).save(new Admin("phtcon@ucsb.edu"));
+        verifyNoMoreInteractions(adminRepository);
+    }
+
+    @Test
+    void test_AlwaysRunOnStartup_handles_exception() {
+        doThrow(new RuntimeException("Simulated error")).when(adminRepository).save(any(Admin.class));
+
+        frontiersStartup.alwaysRunOnStartup();
+
+        verify(adminRepository, times(1)).save(any(Admin.class));
+    }
+}


### PR DESCRIPTION
Closes #13
In this PR, I implemented startup code that adds all the emails in the ADMIN_EMAILS variable to the admins table. There are two ways to test the functionality: locally and through dokku.
Locally:
- Load up my code locally ("git checkout ad-admin-startup" then "git pull origin ad-admin-startup")
- change the ADMIN_EMAILS variable in the .env file to include a new email to test that it gets added
- run mvn spring-boot:run
- go to local host and pull up the H2 console
- click the word ADMINS, and you should see the email you added to ADMIN_EMAILS
<img width="145" alt="Screenshot 2025-05-21 at 8 02 51 PM" src="https://github.com/user-attachments/assets/c2dc1692-a9bc-491a-b3bc-873dd8e0c95e" />

Dokku:
- log in to dokku
- run "dokku config:set frontiers-dev-acdamstedt --no-restart ADMIN_EMAILS=" and include your test email at the end
- then run dokku ps:rebuild frontiers-dev-acdamstedt
- go to https://frontiers-dev-acdamstedt.dokku-07.cs.ucsb.edu/, then log in to swagger and use the admin get all command to see your test email 
- once you have confirmed it worked, run "dokku config:set frontiers-dev-acdamstedt --no-restart ADMIN_EMAILS=djensen@ucsb.edu,benjaminconte@ucsb.edu,samuelzhu@ucsb.edu,divyanipunj@ucsb.edu,sangitakunapuli@ucsb.edu,amey@ucsb.edu,phtcon@ucsb.edu,acdamstedt@ucsb.edu,lzhou@ucsb.edu,hannahzhang@ucsb.edu,yilei_yan@ucsb.edu,zhixiuzhu@ucsb.edu,yuchenliu735@ucsb.edu" and "dokku ps:rebuild frontiers-dev-acdamstedt" to reset the dokku to have the correct admin emails
- NOTE: there might be a way to check whether the email was added through postgres, but I couldn't figure it out