### PR TITLE
ad - Create frontend table component for listing emails

### DIFF
--- a/frontend/src/main/components/Users/RoleEmailTable.js
+++ b/frontend/src/main/components/Users/RoleEmailTable.js
@@ -1,5 +1,5 @@
 import OurTable from "main/components/OurTable";
-import { ButtonColumn } from "main/components/OurTable"; 
+import { ButtonColumn } from "main/components/OurTable";
 
 export default function RoleEmailTable({ data, deleteCallback }) {
   const columns = [

--- a/frontend/src/main/components/Users/RoleEmailTable.js
+++ b/frontend/src/main/components/Users/RoleEmailTable.js
@@ -1,0 +1,14 @@
+import OurTable from "main/components/OurTable";
+import { ButtonColumn } from "main/components/OurTable"; 
+
+export default function RoleEmailTable({ data, deleteCallback }) {
+  const columns = [
+    {
+      Header: "Email",
+      accessor: "email",
+    },
+    ButtonColumn("Delete", "danger", deleteCallback, "RoleEmailTable"),
+  ];
+
+  return <OurTable data={data} columns={columns} testid={"RoleEmailTable"} />;
+}

--- a/frontend/src/stories/components/Users/RoleEmailTable.stories.js
+++ b/frontend/src/stories/components/Users/RoleEmailTable.stories.js
@@ -1,0 +1,24 @@
+import React from "react";
+import RoleEmailTable from "main/components/Users/RoleEmailTable";
+
+export default {
+  title: "components/Users/RoleEmailTable",
+  component: RoleEmailTable,
+};
+
+const sampleData = [
+  { email: "admin@example.com" },
+  { email: "user@example.org" },
+];
+
+const mockDeleteCallback = (cell) => {
+  console.log(`Delete clicked for: ${cell.row.values.email}`);
+};
+
+const Template = (args) => <RoleEmailTable {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  data: sampleData,
+  deleteCallback: mockDeleteCallback,
+};

--- a/frontend/src/tests/components/Users/RoleEmailTable.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailTable.test.js
@@ -19,6 +19,7 @@ describe("RoleEmailTable", () => {
       <RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />,
     );
 
+    expect(screen.getByText("Email")).toBeInTheDocument();
     expect(screen.getByText("admin@example.com")).toBeInTheDocument();
     expect(screen.getByText("user@example.org")).toBeInTheDocument();
 
@@ -32,7 +33,7 @@ describe("RoleEmailTable", () => {
     );
 
     const buttons = screen.getAllByRole("button");
-    expect(buttons.length).toBe(testData.length); // one button per row?
+    expect(buttons.length).toBe(testData.length);
 
     fireEvent.click(buttons[0]);
 
@@ -43,7 +44,29 @@ describe("RoleEmailTable", () => {
     render(
       <RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />,
     );
-    const deleteButton = screen.getAllByRole("button", { name: /delete/i })[0];
-    expect(deleteButton).toBeInTheDocument();
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
+    expect(deleteButtons.length).toBe(testData.length);
+    deleteButtons.forEach((btn) => {
+      expect(btn).toHaveTextContent(/delete/i);
+    });
+  });
+
+  test("renders table with correct testid", () => {
+    render(
+      <RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />,
+    );
+    expect(
+      screen.getByTestId("RoleEmailTable-header-email"),
+    ).toBeInTheDocument();
+  });
+
+  test("Delete button has correct Bootstrap class", () => {
+    render(
+      <RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />,
+    );
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
+    deleteButtons.forEach((btn) => {
+      expect(btn).toHaveClass("btn-danger");
+    });
   });
 });

--- a/frontend/src/tests/components/Users/RoleEmailTable.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailTable.test.js
@@ -69,4 +69,14 @@ describe("RoleEmailTable", () => {
       expect(btn).toHaveClass("btn-danger");
     });
   });
+
+  test("Delete button has correct data-testid using table ID prefix", () => {
+    render(
+      <RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />,
+    );
+    const deleteButton = screen.getByTestId(
+      "RoleEmailTable-cell-row-0-col-Delete-button",
+    );
+    expect(deleteButton).toBeInTheDocument();
+  });
 });

--- a/frontend/src/tests/components/Users/RoleEmailTable.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailTable.test.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import RoleEmailTable from "main/components/Users/RoleEmailTable"; 
+
+const testData = [
+  { email: "admin@example.com" },
+  { email: "user@example.org" },
+];
+
+const mockDeleteCallback = jest.fn();
+
+describe("RoleEmailTable", () => {
+  beforeEach(() => {
+    mockDeleteCallback.mockClear();
+  });
+
+  test("renders table with email data", () => {
+    render(<RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />);
+
+    expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    expect(screen.getByText("user@example.org")).toBeInTheDocument();
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
+    expect(deleteButtons.length).toBe(testData.length);
+  });
+
+  test("calls deleteCallback when Delete button clicked", () => {
+    render(<RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />);
+
+    const firstDeleteButton = screen.getAllByRole("button", { name: /delete/i })[0];
+    fireEvent.click(firstDeleteButton);
+
+    expect(mockDeleteCallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/components/Users/RoleEmailTable.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailTable.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import RoleEmailTable from "main/components/Users/RoleEmailTable"; 
+import RoleEmailTable from "main/components/Users/RoleEmailTable";
 
 const testData = [
   { email: "admin@example.com" },
@@ -15,7 +15,9 @@ describe("RoleEmailTable", () => {
   });
 
   test("renders table with email data", () => {
-    render(<RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />);
+    render(
+      <RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />,
+    );
 
     expect(screen.getByText("admin@example.com")).toBeInTheDocument();
     expect(screen.getByText("user@example.org")).toBeInTheDocument();
@@ -25,24 +27,23 @@ describe("RoleEmailTable", () => {
   });
 
   test("calls deleteCallback when Delete button clicked", () => {
-    render(<RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />);
-  
+    render(
+      <RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />,
+    );
+
     const buttons = screen.getAllByRole("button");
-    expect(buttons.length).toBe(testData.length);  // one button per row?
-  
+    expect(buttons.length).toBe(testData.length); // one button per row?
+
     fireEvent.click(buttons[0]);
-  
+
     expect(mockDeleteCallback).toHaveBeenCalledTimes(1);
   });
-  
+
   test("renders Delete button with correct label", () => {
-    render(<RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />);
+    render(
+      <RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />,
+    );
     const deleteButton = screen.getAllByRole("button", { name: /delete/i })[0];
     expect(deleteButton).toBeInTheDocument();
-  });
-
-  test("OurTable has correct testid attribute", () => {
-    const { container } = render(<RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />);
-    expect(container.querySelector('[data-testid="RoleEmailTable"]')).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/Users/RoleEmailTable.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailTable.test.js
@@ -26,10 +26,23 @@ describe("RoleEmailTable", () => {
 
   test("calls deleteCallback when Delete button clicked", () => {
     render(<RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />);
-
-    const firstDeleteButton = screen.getAllByRole("button", { name: /delete/i })[0];
-    fireEvent.click(firstDeleteButton);
-
+  
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBe(testData.length);  // one button per row?
+  
+    fireEvent.click(buttons[0]);
+  
     expect(mockDeleteCallback).toHaveBeenCalledTimes(1);
+  });
+  
+  test("renders Delete button with correct label", () => {
+    render(<RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />);
+    const deleteButton = screen.getAllByRole("button", { name: /delete/i })[0];
+    expect(deleteButton).toBeInTheDocument();
+  });
+
+  test("OurTable has correct testid attribute", () => {
+    const { container } = render(<RoleEmailTable data={testData} deleteCallback={mockDeleteCallback} />);
+    expect(container.querySelector('[data-testid="RoleEmailTable"]')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #23 
In this PR, I created the default table of emails that can be reused for admins and instructors. It consists of a single email and a delete button. Here is a link to the storybook: https://6823eb49391af42ea971678d-jvpgfluepo.chromatic.com/?path=/story/components-users-roleemailtable--default
<img width="1234" alt="Screenshot 2025-05-22 at 2 34 27 PM" src="https://github.com/user-attachments/assets/5b3f0d6d-e34f-4694-aa1f-7e6a6142c511" />
